### PR TITLE
Selfhost ns form clobbering

### DIFF
--- a/src/test/self/bootstrap_test/helper.cljc
+++ b/src/test/self/bootstrap_test/helper.cljc
@@ -8,5 +8,8 @@
 
 (ns bootstrap-test.helper)
 
-(defn bar [a b]
+(defn multiply-form [a b]
   `(* ~a ~b))
+
+(defn multiply-fn [a b]
+  (* a b))

--- a/src/test/self/bootstrap_test/macros.clj
+++ b/src/test/self/bootstrap_test/macros.clj
@@ -7,7 +7,7 @@
 ;; You must not remove this notice, or any other, from this software.
 
 (ns bootstrap-test.macros
-  (:require [bootstrap-test.helper :refer [bar]]))
+  (:require [bootstrap-test.helper :refer [multiply-form]]))
 
 (defmacro foo [a b]
-  (bar a b))
+  (multiply-form a b))

--- a/src/test/self/bootstrap_test/macros_2.cljc
+++ b/src/test/self/bootstrap_test/macros_2.cljc
@@ -1,0 +1,4 @@
+(ns bootstrap-test.macros-2)
+
+(defmacro wrap [expr]
+  `[:wrapped ~expr])

--- a/src/test/self/bootstrap_test/macros_2.cljc
+++ b/src/test/self/bootstrap_test/macros_2.cljc
@@ -1,4 +1,0 @@
-(ns bootstrap-test.macros-2)
-
-(defmacro wrap [expr]
-  `[:wrapped ~expr])

--- a/src/test/self/self_host/test.cljs
+++ b/src/test/self/self_host/test.cljs
@@ -41,7 +41,8 @@
 (def libs
   {'bootstrap-test.core :cljs
    'bootstrap-test.macros :clj
-   'bootstrap-test.helper :clj})
+   'bootstrap-test.helper :clj
+   'bootstrap-test.macros-2 :cljc})
 
 (defn node-load [{:keys [name macros]} cb]
   (if (contains? libs name)
@@ -842,7 +843,25 @@
 
 (deftest test-eval-str-with-require
   (async done
-    (let [l (latch 3 done)]
+    (let [l (latch 4 done)]
+
+      (cljs/eval-str st
+                     "(ns foo.bar (:require-macros [bootstrap-test.macros-2 :as m2]))\n(m2/wrap 1)"
+                     nil
+                     {:eval node-eval
+                      :load node-load}
+                     (fn [{:keys [value error]}]
+                       (is (nil? error))
+                       (is (= [:wrapped 1] value))
+                       (inc! l)))
+      ;; =>
+      ;; WARNING: No such namespace: m2, could not locate m2.cljs, m2.cljc, or JavaScript source providing "m2" at line 2
+      ;; WARNING: Use of undeclared Var m2/wrap at line 2
+      ;;
+      ;; FAIL in (test-eval-str-with-require) (core-self-test.js:939:362)
+      ;; expected: (nil? error)
+      ;;   actual: (not (nil? #error {:message "ERROR", :data {:tag :cljs/analysis-error}, :cause #object[ReferenceError ReferenceError: m2 is not defined]}))
+
       (cljs/eval-str st
         "(ns foo.bar (:require [bootstrap-test.core]))\n(bootstrap-test.core/foo 3 4)"
         nil


### PR DESCRIPTION
demonstrations of how calling `(ns foo.bar)` removes existing mappings from the namespace, for normal + macro requires.